### PR TITLE
Migrate main to axum 0.7 instead of the unstable git branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.5.0
+
+- Add `From` impls for `HxResponseTrigger`, `HxResponseTriggerAfterSettle`, and
+  `HxResponseTriggerAfterSwap`, allowing them to take any iterator where `T:
+  Into<String>`.
+
 ## v0.4.0
 
 - Added support for all [htmx response

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ guards = ["tower", "futures-core", "pin-project-lite"]
 serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
-axum = { git = "https://github.com/tokio-rs/axum", branch = "main", default-features = false }
+axum = { version = "0.7", default-features = false }
 
 # Optional dependencies required for the `guards` feature.
 tower = { version = "0.4", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ async fn index() -> (&'static str, HxResponseTrigger) {
 can use via the `serde` feature flag and the `HxEvent` type.
 
 ```rust
-use axum_htmx::HxEvent;
+use axum_htmx::serde::HxEvent;
+use serde_json::json;
 
 // Note that we are using `HxResponseTrigger` from the `axum_htmx::serde` module
 // instead of the root module.
@@ -171,7 +172,7 @@ async fn index() -> (&'static str, HxResponseTrigger) {
     )
     .unwrap();
 
-    ("Hello, world!", HxResponseTrigger(event))
+    ("Hello, world!", HxResponseTrigger(vec![event]))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,15 +38,6 @@
 
 Simply run `cargo add axum-htmx` to add the library to your project.
 
-If you are using the unreleased branch of `axum` from GitHub, you can build
-against the `main` version of `axum-htmx` by adding the following to your
-`Cargo.toml`:
-
-```toml
-[dependencies]
-axum-htmx = { git = "https://github.com/robertwayne/axum-htmx" }
-```
-
 ## Extractors
 
 All of the [htmx request headers](https://htmx.org/reference/#request_headers)

--- a/src/responders.rs
+++ b/src/responders.rs
@@ -220,9 +220,13 @@ impl IntoResponseParts for HxReselect {
 #[derive(Debug, Clone)]
 pub struct HxResponseTrigger(pub Vec<String>);
 
-impl HxResponseTrigger {
-    pub fn new(events: &[&str]) -> Self {
-        Self(events.iter().map(|e| e.to_string()).collect())
+impl<T> From<T> for HxResponseTrigger
+where
+    T: IntoIterator,
+    T::Item: ToString,
+{
+    fn from(value: T) -> Self {
+        Self(value.into_iter().map(|s| s.to_string()).collect())
     }
 }
 
@@ -258,6 +262,16 @@ impl IntoResponseParts for HxResponseTrigger {
 #[derive(Debug, Clone)]
 pub struct HxResponseTriggerAfterSettle(pub Vec<String>);
 
+impl<T> From<T> for HxResponseTriggerAfterSettle
+where
+    T: IntoIterator,
+    T::Item: ToString,
+{
+    fn from(value: T) -> Self {
+        Self(value.into_iter().map(|s| s.to_string()).collect())
+    }
+}
+
 impl IntoResponseParts for HxResponseTriggerAfterSettle {
     type Error = HxError;
 
@@ -288,6 +302,16 @@ impl IntoResponseParts for HxResponseTriggerAfterSettle {
 /// See <https://htmx.org/headers/hx-trigger/> for more information.
 #[derive(Debug, Clone)]
 pub struct HxResponseTriggerAfterSwap(pub Vec<String>);
+
+impl<T> From<T> for HxResponseTriggerAfterSwap
+where
+    T: IntoIterator,
+    T::Item: ToString,
+{
+    fn from(value: T) -> Self {
+        Self(value.into_iter().map(|s| s.to_string()).collect())
+    }
+}
 
 impl IntoResponseParts for HxResponseTriggerAfterSwap {
     type Error = HxError;


### PR DESCRIPTION
- Migrate main to axum 0.7 instead of the unstable git branch
- Add `From` impls for iterators where `T: Into<String>` to make constructing  HxResponseTrigger* variants more ergonomic.
- Fix doctest in README