### PR TITLE
Generate docs with cfg badges using nightly compiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 
 [features]
 default = []
+unstable = []
 guards = ["tower", "futures-core", "pin-project-lite"]
 serde = ["dep:serde", "dep:serde_json"]
 
@@ -26,3 +27,6 @@ pin-project-lite = { version = "0.2", optional = true }
 # Optional dependencies required for the `serde` feature.
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -51,6 +51,7 @@ impl<'a, S> Layer<S> for HxRequestGuardLayer<'a> {
     }
 }
 
+/// Tower service that implementes redirecting to non-partial routes.
 #[derive(Debug, Clone)]
 pub struct HxRequestGuard<'a, S> {
     inner: S,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,17 @@
+#![cfg_attr(feature = "unstable", feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
+
 pub mod extractors;
 #[cfg(feature = "guards")]
+#[cfg_attr(feature = "unstable", doc(cfg(feature = "guards")))]
 pub mod guard;
 pub mod headers;
 pub mod responders;
 
 pub use extractors::*;
 #[cfg(feature = "guards")]
+#[cfg_attr(feature = "unstable", doc(cfg(feature = "guards")))]
 pub use guard::*;
 pub use headers::*;
 pub use responders::*;

--- a/src/responders.rs
+++ b/src/responders.rs
@@ -10,6 +10,7 @@ use axum::{
 use crate::headers;
 
 #[cfg(feature = "serde")]
+#[cfg_attr(feature = "unstable", doc(cfg(feature = "serde")))]
 pub mod serde;
 
 const HX_SWAP_INNER_HTML: &str = "innerHTML";


### PR DESCRIPTION
docs.rs generates documentation using nightly compiler, so it's possible to generate feature badges.
Before: 
![image](https://github.com/robertwayne/axum-htmx/assets/107059409/76dcce9e-5c33-4d76-8c23-152770ed8fc6)
After:
![image](https://github.com/robertwayne/axum-htmx/assets/107059409/10b65124-f26d-41fa-a74f-71bee4b0d09c)
![image](https://github.com/robertwayne/axum-htmx/assets/107059409/a386aeae-5a29-47ed-9b91-9266c539ec5d)
