### PR TITLE
Use axum-core,async-trait,http instead of axum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ guards = ["tower", "futures-core", "pin-project-lite"]
 serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
-axum = { version = "0.7", default-features = false }
+axum-core = "0.4"
+http = { version = "1.0.0", default-features = false }
+async-trait = "0.1.74"
 
 # Optional dependencies required for the `guards` feature.
 tower = { version = "0.4", default-features = false, optional = true }

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -1,6 +1,8 @@
 //! Axum extractors for htmx request headers.
 
-use axum::{extract::FromRequestParts, http::request::Parts};
+use async_trait::async_trait;
+use axum_core::extract::FromRequestParts;
+use http::request::Parts;
 
 use crate::{
     HX_BOOSTED, HX_CURRENT_URL, HX_HISTORY_RESTORE_REQUEST, HX_PROMPT, HX_REQUEST, HX_TARGET,
@@ -19,7 +21,7 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub struct HxBoosted(pub bool);
 
-#[axum::async_trait]
+#[async_trait]
 impl<S> FromRequestParts<S> for HxBoosted
 where
     S: Send + Sync,
@@ -45,7 +47,7 @@ where
 #[derive(Debug, Clone)]
 pub struct HxCurrentUrl(pub Option<String>);
 
-#[axum::async_trait]
+#[async_trait]
 impl<S> FromRequestParts<S> for HxCurrentUrl
 where
     S: Send + Sync,
@@ -70,7 +72,7 @@ where
 #[derive(Debug, Clone, Copy)]
 pub struct HxHistoryRestoreRequest(pub bool);
 
-#[axum::async_trait]
+#[async_trait]
 impl<S> FromRequestParts<S> for HxHistoryRestoreRequest
 where
     S: Send + Sync,
@@ -96,7 +98,7 @@ where
 #[derive(Debug, Clone)]
 pub struct HxPrompt(pub Option<String>);
 
-#[axum::async_trait]
+#[async_trait]
 impl<S> FromRequestParts<S> for HxPrompt
 where
     S: Send + Sync,
@@ -124,7 +126,7 @@ where
 #[derive(Debug, Clone, Copy)]
 pub struct HxRequest(pub bool);
 
-#[axum::async_trait]
+#[async_trait]
 impl<S> FromRequestParts<S> for HxRequest
 where
     S: Send + Sync,
@@ -151,7 +153,7 @@ where
 #[derive(Debug, Clone)]
 pub struct HxTarget(pub Option<String>);
 
-#[axum::async_trait]
+#[async_trait]
 impl<S> FromRequestParts<S> for HxTarget
 where
     S: Send + Sync,
@@ -180,7 +182,7 @@ where
 #[derive(Debug, Clone)]
 pub struct HxTriggerName(pub Option<String>);
 
-#[axum::async_trait]
+#[async_trait]
 impl<S> FromRequestParts<S> for HxTriggerName
 where
     S: Send + Sync,
@@ -209,7 +211,7 @@ where
 #[derive(Debug, Clone)]
 pub struct HxTrigger(pub Option<String>);
 
-#[axum::async_trait]
+#[async_trait]
 impl<S> FromRequestParts<S> for HxTrigger
 where
     S: Send + Sync,

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -7,11 +7,8 @@ use std::{
     task::{Context, Poll},
 };
 
-use axum::{
-    http::{header::LOCATION, Request, StatusCode},
-    response::Response,
-};
 use futures_core::ready;
+use http::{header::LOCATION, response::Response, Request, StatusCode};
 use pin_project_lite::pin_project;
 use tower::{Layer, Service};
 

--- a/src/responders.rs
+++ b/src/responders.rs
@@ -2,10 +2,8 @@
 
 use std::convert::Infallible;
 
-use axum::{
-    http::{header::InvalidHeaderValue, HeaderValue, StatusCode, Uri},
-    response::{IntoResponse, IntoResponseParts, ResponseParts},
-};
+use axum_core::response::{IntoResponse, IntoResponseParts, ResponseParts};
+use http::{header::InvalidHeaderValue, HeaderValue, StatusCode, Uri};
 
 use crate::headers;
 
@@ -392,7 +390,7 @@ impl From<serde_json::Error> for HxError {
 }
 
 impl IntoResponse for HxError {
-    fn into_response(self) -> axum::response::Response {
+    fn into_response(self) -> axum_core::response::Response {
         match self {
             Self::InvalidHeaderValue(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "invalid header value").into_response()

--- a/src/responders/serde.rs
+++ b/src/responders/serde.rs
@@ -1,9 +1,7 @@
 use std::collections::HashMap;
 
-use axum::{
-    http::{HeaderValue, Uri},
-    response::{IntoResponseParts, ResponseParts},
-};
+use axum_core::response::{IntoResponseParts, ResponseParts};
+use http::{HeaderValue, Uri};
 use serde::Serialize;
 use serde_json::Value;
 


### PR DESCRIPTION
This pr uses `axum-core`, `async-trait`, `http` dependencies instead of `axum` to reduce dependency count and improve compile times.
## Before:
```
$ time cargo build
________________________________________________________
Executed in   16.97 secs    fish           external
   usr time   42.60 secs    0.00 millis   42.60 secs
   sys time    3.55 secs    1.73 millis    3.55 secs

$ cargo tree | wc -l
67
```
## After:
```
$ time cargo build
________________________________________________________
Executed in    9.81 secs    fish           external
   usr time   23.97 secs    0.00 millis   23.97 secs
   sys time    2.18 secs    1.36 millis    2.18 secs

$ cargo tree | wc -l
39
```
