### PR TITLE
Vary middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ serde = ["dep:serde", "dep:serde_json"]
 axum-core = "0.4"
 http = { version = "1.0", default-features = false }
 async-trait = "0.1"
+axum = "0.7"                                         # TODO: remove
+tokio = { version = "1", features = ["sync"] }       # TODO: hide behind a feature?
 
 # Optional dependencies required for the `guards` feature.
 tower = { version = "0.4", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ http = { version = "1.0", default-features = false }
 async-trait = "0.1"
 axum = "0.7"                                         # TODO: remove
 tokio = { version = "1", features = ["sync"] }       # TODO: hide behind a feature?
+futures = "0.3"                                      # TODO
 
 # Optional dependencies required for the `guards` feature.
 tower = { version = "0.4", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,12 @@ default = []
 unstable = []
 guards = ["tower", "futures-core", "pin-project-lite"]
 serde = ["dep:serde", "dep:serde_json"]
-auto-vary = ["axum", "futures", "tokio"]
+auto-vary = ["futures", "tokio", "tower"]
 
 [dependencies]
 axum-core = "0.4"
 http = { version = "1.0", default-features = false }
 async-trait = "0.1"
-
-# Optional dependencies required for the `auto-vary` feature.
-axum = { version = "0.7", default-features = false, optional = true }
-tokio = { version = "1", features = ["sync"], optional = true }
-futures = { version = "0.3", default-features = false, optional = true }
 
 # Optional dependencies required for the `guards` feature.
 tower = { version = "0.4", default-features = false, optional = true }
@@ -35,6 +30,10 @@ pin-project-lite = { version = "0.2", optional = true }
 # Optional dependencies required for the `serde` feature.
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+
+# Optional dependencies required for the `auto-vary` feature.
+tokio = { version = "1", features = ["sync"], optional = true }
+futures = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
 axum = { version = "0.7", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
 axum = { version = "0.7", default-features = false }
-axum-test = "14"
+axum-test = "15"
 tokio = { version = "1", features = ["full"] }
 tokio-test = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,17 @@ default = []
 unstable = []
 guards = ["tower", "futures-core", "pin-project-lite"]
 serde = ["dep:serde", "dep:serde_json"]
+auto-vary = ["axum", "futures", "tokio"]
 
 [dependencies]
 axum-core = "0.4"
 http = { version = "1.0", default-features = false }
 async-trait = "0.1"
-axum = "0.7"                                         # TODO: remove
-tokio = { version = "1", features = ["sync"] }       # TODO: hide behind a feature?
-futures = "0.3"                                      # TODO
+
+# Optional dependencies required for the `auto-vary` feature.
+axum = { version = "0.7", default-features = false, optional = true }
+tokio = { version = "1", features = ["sync"], optional = true }
+futures = { version = "0.3", default-features = false, optional = true }
 
 # Optional dependencies required for the `guards` feature.
 tower = { version = "0.4", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
   - [Getting Started](#getting-started)
   - [Extractors](#extractors)
   - [Responders](#responders)
+  - [Auto Caching Management](#auto-caching-management)
   - [Request Guards](#request-guards)
   - [Examples](#examples)
     - [Example: Extractors](#example-extractors)
@@ -76,6 +77,8 @@ any of your responses.
 | `HX-Trigger-After-Settle` | `HxResponseTrigger` | `axum_htmx::serde::HxEvent`         |
 | `HX-Trigger-After-Swap`   | `HxResponseTrigger` | `axum_htmx::serde::HxEvent`         |
 
+### Vary Responders
+
 Also, there are corresponding cache-related headers, which you may want to add to
 `GET` responses, depending on the htmx headers.
 
@@ -85,7 +88,7 @@ you need to add `Vary: HX-Request`. That causes the cache to be keyed based on a
 composite of the response URL and the `HX-Request` request header - rather than
 being based just on the response URL._
 
-Refer to [caching htmx docs section](https://htmx.org/docs/#caching) for details.
+Refer to [caching htmx docs section][htmx-caching] for details.
 
 | Header                  | Responder           |
 |-------------------------|---------------------|
@@ -94,10 +97,27 @@ Refer to [caching htmx docs section](https://htmx.org/docs/#caching) for details
 | `Vary: HX-Trigger`      | `VaryHxTrigger`     |
 | `Vary: HX-Trigger-Name` | `VaryHxTriggerName` |
 
+Look at the [Auto Caching Management](#auto-caching-management) section for
+automatic `Vary` headers management.
+
+## Auto Caching Management
+
+__Requires feature `auto-vary`.__
+
+Manual use of [Vary Reponders](#vary-responders) adds fragility to the code,
+because of the need to manually control correspondence between used extractors
+and the responders.
+
+We provide a [middleware](crate::AutoVaryLayer) to address this issue by
+automatically adding `Vary` headers when corresponding extractors are used.
+For example, on extracting [`HxRequest`], the middleware automatically adds 
+`Vary: hx-request` header to the response.
+
+Look at the usage [example][auto-vary-example].
 
 ## Request Guards
 
-__Requires features `guards`.__
+__Requires feature `guards`.__
 
 In addition to the extractors, there is also a route-wide layer request guard
 for the `HX-Request` header. This will redirect any requests without the header
@@ -207,10 +227,11 @@ fn router_two() -> Router {
 ## Feature Flags
 
 <!-- markdownlint-disable -->
-| Flag     | Default  | Description                                                | Dependencies                                |
-|----------|----------|------------------------------------------------------------|---------------------------------------------|
-| `guards` | Disabled | Adds request guard layers.                                 | `tower`, `futures-core`, `pin-project-lite` |
-| `serde`  | Disabled | Adds serde support for the `HxEvent` and `LocationOptions` | `serde`, `serde_json`                       |
+| Flag        | Default  | Description                                                | Dependencies                                |
+|-------------|----------|------------------------------------------------------------|---------------------------------------------|
+| `auto-vary` | Disabled | A middleware to address [HTMx caching issue][htmx-caching] | `futures`, `tokio`, `tower`                 |
+| `guards`    | Disabled | Adds request guard layers.                                 | `tower`, `futures-core`, `pin-project-lite` |
+| `serde`     | Disabled | Adds serde support for the `HxEvent` and `LocationOptions` | `serde`, `serde_json`                       |
 <!-- markdownlint-enable -->
 
 ## Contributing
@@ -233,3 +254,6 @@ cargo +nightly test --all-features
 - **[Apache License, Version 2.0](/LICENSE-APACHE)**
 
 at your option.
+
+[htmx-caching]: https://htmx.org/docs/#caching
+[auto-vary-example]: https://github.com/robertwayne/axum-htmx/blob/main/examples/auto-vary.rs

--- a/examples/auto-vary.rs
+++ b/examples/auto-vary.rs
@@ -1,0 +1,40 @@
+//! Using `auto-vary` middleware
+//!
+//! Don't forget about the feature while running it:
+//! `cargo run --features auto-vary --example auto-vary`
+use std::time::Duration;
+
+use axum::{response::Html, routing::get, serve, Router};
+use axum_htmx::{AutoVaryLayer, HxRequest};
+use tokio::{net::TcpListener, time::sleep};
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new()
+        .route("/", get(handler))
+        // Add the middleware
+        .layer(AutoVaryLayer);
+
+    let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    serve(listener, app).await.unwrap();
+}
+
+// Our handler differentiates full-page GET requests from HTMx-based ones by looking at the `hx-request`
+// requestheader.
+//
+// The middleware sees the usage of the `HxRequest` extractor and automatically adds the
+// `Vary: hx-request` response header.
+async fn handler(HxRequest(hx_request): HxRequest) -> Html<&'static str> {
+    if hx_request {
+        // For HTMx-based GET request, it returns a partial page update
+        sleep(Duration::from_secs(3)).await;
+        return Html("HTMx response");
+    }
+    // While for a normal GET request, it returns the whole page
+    Html(
+        r#"
+        <script src="https://unpkg.com/htmx.org@1"></script>
+        <p hx-get="/" hx-trigger="load">Loading ...</p>
+        "#,
+    )
+}

--- a/src/auto_vary.rs
+++ b/src/auto_vary.rs
@@ -17,7 +17,7 @@ use crate::{
 const MIDDLEWARE_DOUBLE_USE: &str =
     "Configuration error: `axum_httpx::vary_middleware` is used twice";
 
-pub trait Notifier {
+pub(crate) trait Notifier {
     fn sender(&mut self) -> Option<Sender<()>>;
 
     fn notify(&mut self) {
@@ -59,7 +59,7 @@ define_notifiers!(
     HxTriggerNameExtracted
 );
 
-pub async fn vary_middleware(mut request: Request, next: Next) -> Response {
+pub async fn middleware(mut request: Request, next: Next) -> Response {
     let exts = request.extensions_mut();
     let rx_header = [
         (HxRequestExtracted::insert(exts), HX_REQUEST_STR),
@@ -122,7 +122,7 @@ mod tests {
                 "/multiple-extractors",
                 get(|_: HxRequest, _: HxTarget, _: HxTrigger, _: HxTriggerName| async { () }),
             )
-            .layer(axum::middleware::from_fn(vary_middleware));
+            .layer(axum::middleware::from_fn(middleware));
         axum_test::TestServer::new(app).unwrap()
     }
 

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -137,10 +137,11 @@ where
     type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        #[cfg(feature = "auto-vary")]
         parts
             .extensions
-            .get_mut::<crate::vary_middleware::HxRequestExtracted>()
-            .map(crate::vary_middleware::Notifier::notify);
+            .get_mut::<crate::auto_vary::HxRequestExtracted>()
+            .map(crate::auto_vary::Notifier::notify);
 
         if parts.headers.contains_key(HX_REQUEST) {
             return Ok(HxRequest(true));
@@ -169,10 +170,11 @@ where
     type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        #[cfg(feature = "auto-vary")]
         parts
             .extensions
-            .get_mut::<crate::vary_middleware::HxTargetExtracted>()
-            .map(crate::vary_middleware::Notifier::notify);
+            .get_mut::<crate::auto_vary::HxTargetExtracted>()
+            .map(crate::auto_vary::Notifier::notify);
 
         if let Some(target) = parts.headers.get(HX_TARGET) {
             if let Ok(target) = target.to_str() {
@@ -203,10 +205,11 @@ where
     type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        #[cfg(feature = "auto-vary")]
         parts
             .extensions
-            .get_mut::<crate::vary_middleware::HxTriggerNameExtracted>()
-            .map(crate::vary_middleware::Notifier::notify);
+            .get_mut::<crate::auto_vary::HxTriggerNameExtracted>()
+            .map(crate::auto_vary::Notifier::notify);
 
         if let Some(trigger_name) = parts.headers.get(HX_TRIGGER_NAME) {
             if let Ok(trigger_name) = trigger_name.to_str() {
@@ -237,10 +240,11 @@ where
     type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        #[cfg(feature = "auto-vary")]
         parts
             .extensions
-            .get_mut::<crate::vary_middleware::HxTriggerExtracted>()
-            .map(crate::vary_middleware::Notifier::notify);
+            .get_mut::<crate::auto_vary::HxTriggerExtracted>()
+            .map(crate::auto_vary::Notifier::notify);
 
         if let Some(trigger) = parts.headers.get(HX_TRIGGER) {
             if let Ok(trigger) = trigger.to_str() {

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -137,11 +137,10 @@ where
     type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
-        use crate::vary_middleware::{HxRequestExtracted, Notifier};
         parts
             .extensions
-            .get_mut::<HxRequestExtracted>()
-            .map(Notifier::notify);
+            .get_mut::<crate::vary_middleware::HxRequestExtracted>()
+            .map(crate::vary_middleware::Notifier::notify);
 
         if parts.headers.contains_key(HX_REQUEST) {
             return Ok(HxRequest(true));
@@ -170,11 +169,10 @@ where
     type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
-        use crate::vary_middleware::{HxTargetExtracted, Notifier};
         parts
             .extensions
-            .get_mut::<HxTargetExtracted>()
-            .map(Notifier::notify);
+            .get_mut::<crate::vary_middleware::HxTargetExtracted>()
+            .map(crate::vary_middleware::Notifier::notify);
 
         if let Some(target) = parts.headers.get(HX_TARGET) {
             if let Ok(target) = target.to_str() {
@@ -205,6 +203,11 @@ where
     type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get_mut::<crate::vary_middleware::HxTriggerNameExtracted>()
+            .map(crate::vary_middleware::Notifier::notify);
+
         if let Some(trigger_name) = parts.headers.get(HX_TRIGGER_NAME) {
             if let Ok(trigger_name) = trigger_name.to_str() {
                 return Ok(HxTriggerName(Some(trigger_name.to_string())));
@@ -234,6 +237,11 @@ where
     type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get_mut::<crate::vary_middleware::HxTriggerExtracted>()
+            .map(crate::vary_middleware::Notifier::notify);
+
         if let Some(trigger) = parts.headers.get(HX_TRIGGER) {
             if let Ok(trigger) = trigger.to_str() {
                 return Ok(HxTrigger(Some(trigger.to_string())));

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -137,6 +137,12 @@ where
     type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        use crate::vary_middleware::{HxRequestExtracted, Notifier};
+        parts
+            .extensions
+            .get_mut::<HxRequestExtracted>()
+            .map(Notifier::notify);
+
         if parts.headers.contains_key(HX_REQUEST) {
             return Ok(HxRequest(true));
         } else {
@@ -164,6 +170,12 @@ where
     type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        use crate::vary_middleware::{HxTargetExtracted, Notifier};
+        parts
+            .extensions
+            .get_mut::<HxTargetExtracted>()
+            .map(Notifier::notify);
+
         if let Some(target) = parts.headers.get(HX_TARGET) {
             if let Ok(target) = target.to_str() {
                 return Ok(HxTarget(Some(target.to_string())));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@
 mod error;
 pub use error::*;
 
+#[cfg(feature = "auto-vary")]
+#[cfg_attr(feature = "unstable", doc(cfg(feature = "auto-vary")))]
+mod auto_vary;
 pub mod extractors;
 #[cfg(feature = "guards")]
 #[cfg_attr(feature = "unstable", doc(cfg(feature = "guards")))]
@@ -12,6 +15,10 @@ pub mod guard;
 pub mod headers;
 pub mod responders;
 
+#[cfg(feature = "auto-vary")]
+#[cfg_attr(feature = "unstable", doc(cfg(feature = "auto-vary")))]
+#[doc(inline)]
+pub use auto_vary::AutoVaryLayer;
 #[doc(inline)]
 pub use extractors::*;
 #[cfg(feature = "guards")]
@@ -22,6 +29,3 @@ pub use guard::*;
 pub use headers::*;
 #[doc(inline)]
 pub use responders::*;
-
-#[cfg(feature = "auto-vary")]
-pub mod auto_vary;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,6 @@ pub use guard::*;
 pub use headers::*;
 #[doc(inline)]
 pub use responders::*;
+
+pub(crate) mod vary_middleware;
+pub use vary_middleware::vary_middleware;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,5 +23,5 @@ pub use headers::*;
 #[doc(inline)]
 pub use responders::*;
 
-pub(crate) mod vary_middleware;
-pub use vary_middleware::vary_middleware;
+#[cfg(feature = "auto-vary")]
+pub mod auto_vary;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use error::*;
 
 #[cfg(feature = "auto-vary")]
 #[cfg_attr(feature = "unstable", doc(cfg(feature = "auto-vary")))]
-mod auto_vary;
+pub mod auto_vary;
 pub mod extractors;
 #[cfg(feature = "guards")]
 #[cfg_attr(feature = "unstable", doc(cfg(feature = "guards")))]
@@ -18,7 +18,7 @@ pub mod responders;
 #[cfg(feature = "auto-vary")]
 #[cfg_attr(feature = "unstable", doc(cfg(feature = "auto-vary")))]
 #[doc(inline)]
-pub use auto_vary::AutoVaryLayer;
+pub use auto_vary::*;
 #[doc(inline)]
 pub use extractors::*;
 #[cfg(feature = "guards")]

--- a/src/vary_middleware.rs
+++ b/src/vary_middleware.rs
@@ -1,0 +1,134 @@
+use crate::{
+    headers::{HX_REQUEST_STR, HX_TARGET_STR},
+    HxError,
+};
+use axum::{extract::Request, middleware::Next, response::Response};
+use axum_core::response::IntoResponse;
+use http::{
+    header::{HeaderValue, VARY},
+    Extensions,
+};
+use std::sync::Arc;
+use tokio::sync::oneshot::{self, Receiver, Sender};
+
+const MIDDLEWARE_DOUBLE_USE: &str =
+    "Configuration error: `axum_httpx::vary_middleware` is used twice";
+
+#[derive(Clone)]
+pub(crate) struct HxRequestExtracted(Option<Arc<Sender<()>>>);
+
+#[derive(Clone)]
+pub(crate) struct HxTargetExtracted(Option<Arc<Sender<()>>>);
+
+pub trait Notifier {
+    fn sender(&mut self) -> Option<Sender<()>>;
+
+    fn notify(&mut self) {
+        if let Some(sender) = self.sender().take() {
+            sender.send(()).ok();
+        }
+    }
+}
+
+impl Notifier for HxRequestExtracted {
+    fn sender(&mut self) -> Option<Sender<()>> {
+        self.0.take().and_then(Arc::into_inner)
+    }
+}
+
+impl Notifier for HxTargetExtracted {
+    fn sender(&mut self) -> Option<Sender<()>> {
+        self.0.take().and_then(Arc::into_inner)
+    }
+}
+
+impl HxRequestExtracted {
+    fn insert_into_extensions(extensions: &mut Extensions) -> Receiver<()> {
+        let (tx, rx) = oneshot::channel();
+        if extensions.insert(Self(Some(Arc::new(tx)))).is_some() {
+            panic!("{}", MIDDLEWARE_DOUBLE_USE);
+        }
+        rx
+    }
+}
+
+impl HxTargetExtracted {
+    fn insert_into_extensions(extensions: &mut Extensions) -> Receiver<()> {
+        let (tx, rx) = oneshot::channel();
+        if extensions.insert(Self(Some(Arc::new(tx)))).is_some() {
+            panic!("{}", MIDDLEWARE_DOUBLE_USE);
+        }
+        rx
+    }
+}
+
+pub async fn vary_middleware(mut request: Request, next: Next) -> Response {
+    let hx_request_rx = HxRequestExtracted::insert_into_extensions(request.extensions_mut());
+    let hx_target_rx = HxTargetExtracted::insert_into_extensions(request.extensions_mut());
+
+    let mut response = next.run(request).await;
+
+    let mut used = Vec::with_capacity(4);
+    if hx_request_rx.await.is_ok() {
+        used.push(HX_REQUEST_STR)
+    }
+    if hx_target_rx.await.is_ok() {
+        used.push(HX_TARGET_STR)
+    }
+
+    if !used.is_empty() {
+        let value = match HeaderValue::from_str(&used.join(", ")) {
+            Ok(x) => x,
+            Err(e) => return HxError::from(e).into_response(),
+        };
+        if let Err(e) = response.headers_mut().try_append(VARY, value) {
+            return HxError::from(e).into_response();
+        }
+    }
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{HxRequest, HxTarget};
+    use axum::{routing::get, Router};
+
+    use super::*;
+
+    fn vary_headers(resp: &axum_test::TestResponse) -> Vec<HeaderValue> {
+        resp.iter_headers_by_name("vary").cloned().collect()
+    }
+
+    #[tokio::test]
+    async fn multiple_headers() {
+        let app = Router::new()
+            .route("/no-extractors", get(|| async { () }))
+            .route("/single-extractor", get(|_: HxRequest| async { () }))
+            // Extractors can be used multiple times e.g. in middlewares
+            .route(
+                "/repeated-extractor",
+                get(|_: HxRequest, _: HxRequest| async { () }),
+            )
+            .route(
+                "/multiple-extractors",
+                get(|_: HxRequest, _: HxTarget| async { () }),
+            )
+            .layer(axum::middleware::from_fn(vary_middleware));
+        let server = axum_test::TestServer::new(app).unwrap();
+
+        assert!(vary_headers(&server.get("/no-extractors").await).is_empty());
+        assert_eq!(
+            vary_headers(&server.get("/single-extractor").await),
+            [HX_REQUEST_STR]
+        );
+        assert_eq!(
+            vary_headers(&server.get("/repeated-extractor").await),
+            [HX_REQUEST_STR]
+        );
+        assert_eq!(
+            vary_headers(&server.get("/multiple-extractors").await),
+            [format!("{HX_REQUEST_STR}, {HX_TARGET_STR}")]
+        );
+    }
+}

--- a/src/vary_middleware.rs
+++ b/src/vary_middleware.rs
@@ -24,6 +24,8 @@ pub trait Notifier {
             sender.send(()).ok();
         }
     }
+
+    fn insert_into_extensions(extensions: &mut Extensions) -> Receiver<()>;
 }
 
 macro_rules! define_notifiers {
@@ -36,9 +38,7 @@ macro_rules! define_notifiers {
                 fn sender(&mut self) -> Option<Sender<()>> {
                     self.0.take().and_then(Arc::into_inner)
                 }
-            }
 
-            impl $name {
                 fn insert_into_extensions(extensions: &mut Extensions) -> Receiver<()> {
                     let (tx, rx) = oneshot::channel();
                     if extensions.insert(Self(Some(Arc::new(tx)))).is_some() {

--- a/src/vary_middleware.rs
+++ b/src/vary_middleware.rs
@@ -1,15 +1,17 @@
-use crate::{
-    headers::{HX_REQUEST_STR, HX_TARGET_STR},
-    HxError,
-};
+use std::sync::Arc;
+
 use axum::{extract::Request, middleware::Next, response::Response};
 use axum_core::response::IntoResponse;
 use http::{
     header::{HeaderValue, VARY},
     Extensions,
 };
-use std::sync::Arc;
 use tokio::sync::oneshot::{self, Receiver, Sender};
+
+use crate::{
+    headers::{HX_REQUEST_STR, HX_TARGET_STR},
+    HxError,
+};
 
 const MIDDLEWARE_DOUBLE_USE: &str =
     "Configuration error: `axum_httpx::vary_middleware` is used twice";
@@ -91,10 +93,10 @@ pub async fn vary_middleware(mut request: Request, next: Next) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use crate::{HxRequest, HxTarget};
     use axum::{routing::get, Router};
 
     use super::*;
+    use crate::{HxRequest, HxTarget};
 
     fn vary_headers(resp: &axum_test::TestResponse) -> Vec<HeaderValue> {
         resp.iter_headers_by_name("vary").cloned().collect()


### PR DESCRIPTION
Here's how it looks (just a draft yet). Let me know if you're ok with the approach before I finish it.

Also I've noticed you implemented tower middleware in the guard, is there any benefits compared to `axum::middleware::from_fn`. I can't imagine how one would use the crate without axum, so depending on it instead of `axum-core` seems ok, isn't it?