### PR TITLE
Update to axum-core 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ axum = { version = "0.8", default-features = false, features = [
     "http1",
 ] }
 # axum-test = "16"
-axum-test = { git = "https://github.com/JosephLenton/axum-test.git", branch = "feat-axum-8" }
+axum-test = { version = "17.0.1" }
 tokio = { version = "1", features = ["full"] }
 tokio-test = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,8 @@ serde = ["dep:serde", "dep:serde_json"]
 auto-vary = ["futures", "tokio", "tower"]
 
 [dependencies]
-axum-core = "0.4"
+axum-core = "0.5"
 http = { version = "1", default-features = false }
-async-trait = "0.1"
 
 # Optional dependencies required for the `guards` feature.
 tower = { version = "0.5", default-features = false, optional = true }
@@ -36,8 +35,12 @@ tokio = { version = "1", features = ["sync"], optional = true }
 futures = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
-axum = { version = "0.7", default-features = false }
-axum-test = "16"
+axum = { version = "0.8", default-features = false, features = [
+    "tokio",
+    "http1",
+] }
+# axum-test = "16"
+axum-test = { git = "https://github.com/JosephLenton/axum-test.git", branch = "feat-axum-8" }
 tokio = { version = "1", features = ["full"] }
 tokio-test = "0.4"
 

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -1,6 +1,5 @@
 //! Axum extractors for htmx request headers.
 
-use async_trait::async_trait;
 use axum_core::extract::FromRequestParts;
 use http::request::Parts;
 
@@ -21,7 +20,6 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub struct HxBoosted(pub bool);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for HxBoosted
 where
     S: Send + Sync,
@@ -47,7 +45,6 @@ where
 #[derive(Debug, Clone)]
 pub struct HxCurrentUrl(pub Option<http::Uri>);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for HxCurrentUrl
 where
     S: Send + Sync,
@@ -75,7 +72,6 @@ where
 #[derive(Debug, Clone, Copy)]
 pub struct HxHistoryRestoreRequest(pub bool);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for HxHistoryRestoreRequest
 where
     S: Send + Sync,
@@ -101,7 +97,6 @@ where
 #[derive(Debug, Clone)]
 pub struct HxPrompt(pub Option<String>);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for HxPrompt
 where
     S: Send + Sync,
@@ -129,7 +124,6 @@ where
 #[derive(Debug, Clone, Copy)]
 pub struct HxRequest(pub bool);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for HxRequest
 where
     S: Send + Sync,
@@ -162,7 +156,6 @@ where
 #[derive(Debug, Clone)]
 pub struct HxTarget(pub Option<String>);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for HxTarget
 where
     S: Send + Sync,
@@ -197,7 +190,6 @@ where
 #[derive(Debug, Clone)]
 pub struct HxTriggerName(pub Option<String>);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for HxTriggerName
 where
     S: Send + Sync,
@@ -232,7 +224,6 @@ where
 #[derive(Debug, Clone)]
 pub struct HxTrigger(pub Option<String>);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for HxTrigger
 where
     S: Send + Sync,


### PR DESCRIPTION
Update `axum-core` to version 0.5 to support the release of axum 0.8. This requires updating the `Cargo.toml`, as well as removing all references to `async-trait` since it is no longer required for extractors.