### PR TITLE
Remove `Uri` from responders - replace with `String`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ any of your responses.
 
 | Header                    | Responder           | Value                               |
 |---------------------------|---------------------|-------------------------------------|
-| `HX-Location`             | `HxLocation`        | `axum::http::Uri`                   |
-| `HX-Push-Url`             | `HxPushUrl`         | `axum::http::Uri`                   |
-| `HX-Redirect`             | `HxRedirect`        | `axum::http::Uri`                   |
+| `HX-Location`             | `HxLocation`        | `String`                   |
+| `HX-Push-Url`             | `HxPushUrl`         | `String`                   |
+| `HX-Redirect`             | `HxRedirect`        | `String`                   |
 | `HX-Refresh`              | `HxRefresh`         | `bool`                              |
-| `HX-Replace-Url`          | `HxReplaceUrl`      | `axum::http::Uri`                   |
+| `HX-Replace-Url`          | `HxReplaceUrl`      | `String`                   |
 | `HX-Reswap`               | `HxReswap`          | `axum_htmx::responders::SwapOption` |
 | `HX-Retarget`             | `HxRetarget`        | `String`                            |
 | `HX-Reselect`             | `HxReselect`        | `String`                            |

--- a/src/responders.rs
+++ b/src/responders.rs
@@ -1,9 +1,9 @@
 //! Axum responses for htmx response headers.
 
-use std::{convert::Infallible, str::FromStr};
+use std::convert::Infallible;
 
 use axum_core::response::{IntoResponseParts, ResponseParts};
-use http::{HeaderValue, Uri};
+use http::HeaderValue;
 
 use crate::{headers, HxError};
 
@@ -32,7 +32,7 @@ const HX_SWAP_NONE: &str = "none";
 ///
 /// See <https://htmx.org/headers/hx-push-url/> for more information.
 #[derive(Debug, Clone)]
-pub struct HxPushUrl(pub Uri);
+pub struct HxPushUrl(pub String);
 
 impl IntoResponseParts for HxPushUrl {
     type Error = HxError;
@@ -47,17 +47,9 @@ impl IntoResponseParts for HxPushUrl {
     }
 }
 
-impl From<Uri> for HxPushUrl {
-    fn from(uri: Uri) -> Self {
-        Self(uri)
-    }
-}
-
-impl<'a> TryFrom<&'a str> for HxPushUrl {
-    type Error = <Uri as FromStr>::Err;
-
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        Ok(Self(value.parse()?))
+impl<'a> From<&'a str> for HxPushUrl {
+    fn from(value: &'a str) -> Self {
+        Self(value.to_string())
     }
 }
 
@@ -68,7 +60,7 @@ impl<'a> TryFrom<&'a str> for HxPushUrl {
 /// Will fail if the supplied Uri contains characters that are not visible ASCII
 /// (32-127).
 #[derive(Debug, Clone)]
-pub struct HxRedirect(pub Uri);
+pub struct HxRedirect(pub String);
 
 impl IntoResponseParts for HxRedirect {
     type Error = HxError;
@@ -83,17 +75,9 @@ impl IntoResponseParts for HxRedirect {
     }
 }
 
-impl From<Uri> for HxRedirect {
-    fn from(uri: Uri) -> Self {
-        Self(uri)
-    }
-}
-
-impl<'a> TryFrom<&'a str> for HxRedirect {
-    type Error = <Uri as FromStr>::Err;
-
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        Ok(Self(value.parse()?))
+impl<'a> From<&'a str> for HxRedirect {
+    fn from(value: &'a str) -> Self {
+        Self(value.to_string())
     }
 }
 
@@ -137,7 +121,7 @@ impl IntoResponseParts for HxRefresh {
 ///
 /// See <https://htmx.org/headers/hx-replace-url/> for more information.
 #[derive(Debug, Clone)]
-pub struct HxReplaceUrl(pub Uri);
+pub struct HxReplaceUrl(pub String);
 
 impl IntoResponseParts for HxReplaceUrl {
     type Error = HxError;
@@ -152,17 +136,9 @@ impl IntoResponseParts for HxReplaceUrl {
     }
 }
 
-impl From<Uri> for HxReplaceUrl {
-    fn from(uri: Uri) -> Self {
-        Self(uri)
-    }
-}
-
-impl<'a> TryFrom<&'a str> for HxReplaceUrl {
-    type Error = <Uri as FromStr>::Err;
-
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        Ok(Self(value.parse()?))
+impl<'a> From<&'a str> for HxReplaceUrl {
+    fn from(value: &'a str) -> Self {
+        Self(value.to_string())
     }
 }
 

--- a/src/responders.rs
+++ b/src/responders.rs
@@ -40,7 +40,7 @@ impl IntoResponseParts for HxPushUrl {
     fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
         res.headers_mut().insert(
             headers::HX_PUSH_URL,
-            HeaderValue::from_maybe_shared(self.0.to_string())?,
+            HeaderValue::from_maybe_shared(self.0)?,
         );
 
         Ok(res)
@@ -68,7 +68,7 @@ impl IntoResponseParts for HxRedirect {
     fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
         res.headers_mut().insert(
             headers::HX_REDIRECT,
-            HeaderValue::from_maybe_shared(self.0.to_string())?,
+            HeaderValue::from_maybe_shared(self.0)?,
         );
 
         Ok(res)
@@ -129,7 +129,7 @@ impl IntoResponseParts for HxReplaceUrl {
     fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
         res.headers_mut().insert(
             headers::HX_REPLACE_URL,
-            HeaderValue::from_maybe_shared(self.0.to_string())?,
+            HeaderValue::from_maybe_shared(self.0)?,
         );
 
         Ok(res)


### PR DESCRIPTION
This is a PR for #31 

I have decided to leave `HxCurrentUrl` with `Uri` dependency, as this is aligned with how `axum` extracts the current Uri. I have removed `Uri` dependency from all Url/Location headers.

For more information, see [hyper `Uri` does not support `#fragment`](https://github.com/hyperium/http/issues/127)

# Changes

- Replace `Uri` with `String` for `HxLocation` responder
- Replace `Uri` with `String` for `HxPushUrl` responder
- Replace `Uri` with `String` for `HxRedirect` responder
- Replace `Uri` with `String` for `HxReplaceUrl` responder